### PR TITLE
Add --max-literal-section.

### DIFF
--- a/bin/pngunzip.toit
+++ b/bin/pngunzip.toit
@@ -53,7 +53,7 @@ main args/List:
               --type="string",
           cli.OptionInt "max-literal-section"
               --default=64000
-              --short-help="Maximum size of a zlib section (default: 64000).",
+              --short-help="Maximum size of a zlib section.",
           cli.Option "override-chunk"
               --multi
               --short-help="Override a named chunk."

--- a/bin/pngunzip.toit
+++ b/bin/pngunzip.toit
@@ -51,6 +51,9 @@ main args/List:
               --multi
               --short-help="Preserve a named chunk."
               --type="string",
+          cli.OptionInt "max-literal-section"
+              --default=64000
+              --short-help="Maximum size of a zlib section (default: 64000).",
           cli.Option "override-chunk"
               --multi
               --short-help="Override a named chunk."
@@ -127,7 +130,8 @@ unzip parsed -> none:
 
   bytes-per-line := png.byte-width + 1
   // Avoid hitting the 64k limit on literal blocks.
-  lines-per-block := 64000 / bytes-per-line
+  lines-per-block := parsed["max-literal-section"] / bytes-per-line
+  if lines-per-block < 1: throw "max-literal-section too small"
   buffer := ByteArray (bytes-per-line * lines-per-block)
 
   lut := invert-bits ? (ByteArray 256: it ^ 0xff) : null


### PR DESCRIPTION
Up to 64k of image data can be stored uncompressed in a zlib block, but this means we need rather large PNG files to test random access across literal zlib blocks. Add an option to split the image into more literal blocks.